### PR TITLE
feat: enable GCE spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ GPLv3 license.
 
 #### Server Configs 📋
 
-##### Spot (Preemptible) Instances
+##### Spot Instances
 
 When you want to run a Minecraft server on a spot instance, you can use the following configuration options:
 
@@ -472,8 +472,7 @@ spot: <true |false>
 ...
 ```
 
-This will enable the server to be run on a spot instance. At the moment, this is only supported by AWS, Azure. In GCP,
-this will be only a preemptible instance and will live for a maximum of 24 hours.
+This will enable the server to be run on a spot instance. At the moment, this is only supported by AWS, Azure and GCP.
 
 ##### MinecraftProxy Config 📡
 

--- a/internal/cloud/gce/gce.go
+++ b/internal/cloud/gce/gce.go
@@ -125,11 +125,12 @@ func (g *GCE) CreateServer(args automation.ServerArgs) (*automation.ResourceResu
 
 	scheduling := &compute.Scheduling{
 		AutomaticRestart: googleapi.Bool(!args.MinecraftResource.IsSpot()),
-		Preemptible:      args.MinecraftResource.IsSpot(),
 	}
 	if args.MinecraftResource.IsSpot() {
+		scheduling.ProvisioningModel = "SPOT"
 		scheduling.OnHostMaintenance = "TERMINATE"
 	} else {
+		scheduling.ProvisioningModel = "STANDARD"
 		scheduling.OnHostMaintenance = "MIGRATE"
 	}
 


### PR DESCRIPTION
With this PR, `minectl 🗺` supports spot VMs. Spot VMs are virtual machine instances with the spot provisioning model. Spot VMs are available at a 60-91% discount compared to the price of standard VMs.

Fixes #342 

### Thank you for making `minectl 🗺` better

Please reference the issue this PR is fixing.

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/dirien/.github/blob/main/CODE_OF_CONDUCT.md)).