### PR TITLE
feat: enable bedrock 1.19 on ubuntu 22.04

### DIFF
--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -445,6 +445,8 @@ URL=$(curl -s https://bedrock-version.minectl.ediri.online/binary/1.17.10.04)
 curl -sLSf $URL > /tmp/bedrock-server.zip
 unzip -o /tmp/bedrock-server.zip -d /minecraft
 chmod +x /minecraft/bedrock_server
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 echo "eula=false" > /minecraft/eula.txt
 mv /tmp/server.properties /minecraft/server.properties
 chmod a+rwx /minecraft
@@ -758,6 +760,8 @@ runcmd:
   - curl -sLSf $URL > /tmp/bedrock-server.zip
   - unzip -o /tmp/bedrock-server.zip -d /minecraft
   - chmod +x /minecraft/bedrock_server
+  - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+  - dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
   - echo "eula=false" > /minecraft/eula.txt
   - mv /tmp/server.properties /minecraft/server.properties
   - chmod a+rwx /minecraft
@@ -1247,6 +1251,8 @@ URL=$(curl -s https://bedrock-version.minectl.ediri.online/binary/1.17.10.04)
 curl -sLSf $URL > /tmp/bedrock-server.zip
 unzip -o /tmp/bedrock-server.zip -d /minecraft
 chmod +x /minecraft/bedrock_server
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 echo "eula=false" > /minecraft/eula.txt
 mv /tmp/server.properties /minecraft/server.properties
 chmod a+rwx /minecraft
@@ -3227,6 +3233,8 @@ URL=$(curl -s https://bedrock-version.minectl.ediri.online/binary/1.17.10.04)
 curl -sLSf $URL > /tmp/bedrock-server.zip
 unzip -o /tmp/bedrock-server.zip -d /minecraft
 chmod +x /minecraft/bedrock_server
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 echo "eula=false" > /minecraft/eula.txt
 mv /tmp/server.properties /minecraft/server.properties
 chmod a+rwx /minecraft

--- a/internal/template/templates/bash/bedrock-binary.tmpl
+++ b/internal/template/templates/bash/bedrock-binary.tmpl
@@ -3,4 +3,6 @@ URL=$(curl -s https://bedrock-version.minectl.ediri.online/binary/{{ .Spec.Minec
 curl -sLSf $URL > /tmp/bedrock-server.zip
 unzip -o /tmp/bedrock-server.zip -d /minecraft
 chmod +x /minecraft/bedrock_server
+wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 {{- end }}

--- a/internal/template/templates/cloud-init/bedrock-binary.yaml.tmpl
+++ b/internal/template/templates/cloud-init/bedrock-binary.yaml.tmpl
@@ -3,4 +3,6 @@
   - curl -sLSf $URL > /tmp/bedrock-server.zip
   - unzip -o /tmp/bedrock-server.zip -d /minecraft
   - chmod +x /minecraft/bedrock_server
+  - wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
+  - dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

### Thank you for making `minectl 🗺` better

Please reference the issue this PR is fixing.

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct](https://github.com/dirien/.github/blob/main/CODE_OF_CONDUCT.md).
