### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/docs/getting-started-exoscale.md
+++ b/docs/getting-started-exoscale.md
@@ -30,7 +30,7 @@ ssh-keygen -t rsa -f ./minecraft
 
 ## Create MinecraftServer config
 Create a file named server-exoscale.yaml with the example below.
-Have a look at https://minecraft.fandom.com/wiki/Server.properties/ to configure your server.
+Have a look at https://minecraft.wiki/w/Server.properties to configure your server.
 
 ```bash
 apiVersion: minectl.ediri.io/v1alpha1


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct](https://github.com/dirien/.github/blob/main/CODE_OF_CONDUCT.md).
