### PR TITLE
docs: add AGENTS.md for AI agent onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ revive.log
 **/ssh/
 **/oracleidentitycloudservice_*.pem
 **/*-openrc.sh
+.claude/
+.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,166 @@
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-03-21 | Last verified: 2026-03-21 -->
+
+# AGENTS.md
+
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only.
+
+## Commands (verified 2026-03-21)
+> Source: Makefile, go.mod
+
+<!-- AGENTS-GENERATED:START commands -->
+| Task | Command | ~Time |
+|------|---------|-------|
+| Typecheck | `go build -v ./...` | ~15s |
+| Lint | `golangci-lint run --timeout 10m -E goimports --fix` | ~30s |
+| Format | `gofmt -w .` | ~5s |
+| Test (single) | `go test -v -race ./internal/ui/...` | ~2s |
+| Test (all) | `go test -v ./...` | ~10s |
+| Build (local) | `go build .` | ~10s |
+| Build (cross) | `make build` | ~30s |
+| Install | `go install .` | ~10s |
+| Coverage | `make coverage` | ~15s |
+<!-- AGENTS-GENERATED:END commands -->
+
+> If commands fail, verify against `Makefile` or ask user to update.
+
+## Workflow
+1. **Before coding**: Read nearest `AGENTS.md` for the area you're touching
+2. **After each change**: Run the smallest relevant check (lint → typecheck → single test)
+3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
+4. **Before claiming done**: Run verification and **show output as evidence**
+
+## File Map
+<!-- AGENTS-GENERATED:START filemap -->
+```
+main.go                          → entrypoint, injects version/commit/date
+cmd/minectl/                     → CLI commands (cobra): create, delete, list, update, wizard, plugins, rcon
+internal/
+  logging/                       → zap-based structured logging
+  manifest/                      → YAML manifest parsing and JSON schema validation
+  provisioner/                   → cloud provider orchestration via minectl-sdk
+  rcon/                          → Minecraft RCON interactive prompt
+  ui/                            → TUI components (spinner, table, forms via bubbletea/huh)
+config/                          → server config templates per Minecraft edition
+docs/                            → documentation and images
+Dockerfile                       → chainguard static image, copies binary
+Makefile                         → build, test, lint, coverage targets
+```
+<!-- AGENTS-GENERATED:END filemap -->
+
+## Golden Samples (follow these patterns)
+<!-- AGENTS-GENERATED:START golden-samples -->
+| For | Reference | Key patterns |
+|-----|-----------|--------------|
+| CLI command | `cmd/minectl/create.go` | Cobra RunE, flag parsing, provisioner creation |
+| Provisioner | `internal/provisioner/provisioner.go` | Interface, cloud provider switch, spinner lifecycle |
+| UI component | `internal/ui/spinner.go` | Bubbletea model, headless vs interactive |
+| Test pattern | `internal/ui/ui_test.go` | Table-driven tests, headless/interactive variants |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+## Utilities (check before creating new)
+<!-- AGENTS-GENERATED:START utilities -->
+| Need | Use | Location |
+|------|-----|----------|
+| Cloud provisioning | `minectl-sdk` | `github.com/dirien/minectl-sdk` (external) |
+| CLI framework | `cobra` | `github.com/spf13/cobra` |
+| TUI forms | `huh` | `github.com/charmbracelet/huh` |
+| TUI spinners/tables | `bubbletea` + `bubbles` | `internal/ui/` |
+| Logging | `zap` | `internal/logging/` |
+| YAML parsing | `sigs.k8s.io/yaml` | `internal/manifest/` |
+| JSON schema validation | `gojsonschema` | `internal/manifest/` |
+| Error wrapping | `pkg/errors` | Used throughout |
+<!-- AGENTS-GENERATED:END utilities -->
+
+## Heuristics (quick decisions)
+<!-- AGENTS-GENERATED:START heuristics -->
+| When | Do |
+|------|-----|
+| Adding cloud provider | Add case in `internal/provisioner/provisioner.go:getProvisioner()`, implement in `minectl-sdk` |
+| Adding CLI command | New file in `cmd/minectl/`, register in `minectl.go:init()` |
+| Adding server edition | New config dir under `config/`, update manifest parsing |
+| Version injection | Via ldflags in Makefile: `-X main.version=...` |
+| Headless mode | Use `--headless` flag; switches UI to structured logging |
+| Committing | Use Conventional Commits (`feat:`, `fix:`, `docs:`, etc.) |
+| Adding dependency | Ask first — we minimize deps |
+| Unsure about pattern | Check Golden Samples above |
+<!-- AGENTS-GENERATED:END heuristics -->
+
+## Repository Settings
+<!-- AGENTS-GENERATED:START repo-settings -->
+- **Default branch:** `main`
+- **Go version:** 1.24.9
+- **Module:** `github.com/dirien/minectl`
+- **Docker:** chainguard static base image
+- **CI:** GitHub Actions (lock-inactive workflow)
+<!-- AGENTS-GENERATED:END repo-settings -->
+
+## Key Decisions
+<!-- AGENTS-GENERATED:START key-decisions -->
+- **External SDK:** Core cloud logic lives in `github.com/dirien/minectl-sdk`, not in this repo. This repo is the CLI wrapper.
+- **Charmbracelet TUI:** Interactive mode uses bubbletea/huh/lipgloss; headless mode falls back to zap logging.
+- **Multi-cloud:** 15 cloud providers supported via provider-specific env vars (see `provisioner.go`).
+- **Manifest-driven:** Server config is YAML manifests validated against JSON schema.
+<!-- AGENTS-GENERATED:END key-decisions -->
+
+## Boundaries
+
+### Always Do
+- Run pre-commit checks before committing
+- Add tests for new code paths
+- Use conventional commit format: `type(scope): subject`
+- Follow Go 1.24 conventions and idioms
+- Show test output as evidence before claiming work is complete
+
+### Ask First
+- Adding new dependencies
+- Modifying CI/CD configuration
+- Changing public API signatures or CLI flags
+- Changes to `minectl-sdk` (external dependency)
+- Repo-wide refactoring or rewrites
+
+### Never Do
+- Commit secrets, credentials, or cloud provider tokens
+- Modify vendor/ or generated files
+- Push directly to main branch
+- Use `ioutil.*` (deprecated)
+- Commit go.sum without go.mod changes
+
+## Contributing (for AI agents)
+- **Comprehension**: Understand the problem before submitting code. Read the linked issue, understand *why* the change is needed.
+- **Context**: Every PR must explain trade-offs and link to the issue it addresses.
+- **Continuity**: Respond to review feedback. Drive-by PRs without follow-up will be closed.
+
+<!-- AGENTS-GENERATED:START module-boundaries -->
+## Module Boundaries
+- `cmd/minectl/` → CLI layer only; no business logic, delegates to `internal/`
+- `internal/provisioner/` → orchestrates `minectl-sdk`; no direct cloud API calls
+- `internal/ui/` → presentation only; no business logic
+- `internal/manifest/` → parsing/validation only; no side effects
+- `internal/logging/` → logging setup; used by `ui`
+- `internal/rcon/` → RCON protocol; standalone
+<!-- AGENTS-GENERATED:END module-boundaries -->
+
+## Terminology
+| Term | Means |
+|------|-------|
+| minectl | This CLI tool for provisioning Minecraft servers |
+| minectl-sdk | External Go SDK containing cloud provider implementations |
+| manifest | YAML file describing desired server configuration |
+| edition | Minecraft variant: java, bedrock, fabric, forge, papermc, etc. |
+| RCON | Remote Console protocol for Minecraft server administration |
+| headless | Non-interactive mode for CI/automation (structured log output) |
+
+## Index of scoped AGENTS.md
+<!-- AGENTS-GENERATED:START scope-index -->
+| Directory | Focus |
+|-----------|-------|
+| [`cmd/minectl/`](./cmd/minectl/AGENTS.md) | CLI commands, cobra patterns, flag handling |
+<!-- AGENTS-GENERATED:END scope-index -->
+
+> **Agents**: When you read or edit files in a listed directory, you **must** load its AGENTS.md first.
+
+## When instructions conflict
+The nearest `AGENTS.md` wins. Explicit user prompts override files.
+- For Go-specific patterns, defer to language idioms and standard library conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cmd/minectl/AGENTS.md
+++ b/cmd/minectl/AGENTS.md
@@ -1,0 +1,90 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-03-21 -->
+
+# AGENTS.md — cmd/minectl (CLI Commands)
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+Cobra-based CLI entry point for minectl. Each file defines one subcommand. All commands delegate to `internal/` packages for business logic.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `minectl.go` | Root command, global flags (`--headless`, `--verbose`, `--log-encoding`), version check, subcommand registration in `init()` |
+| `create.go` | `minectl create` — provisions a Minecraft server from manifest |
+| `delete.go` | `minectl delete` — tears down a server by ID |
+| `update.go` | `minectl update` — updates server edition/config |
+| `list.go` | `minectl list` — lists servers for a given provider/region |
+| `rcon.go` | `minectl rcon` — opens interactive RCON console |
+| `plugins.go` | `minectl plugins` — uploads plugins to a running server |
+| `wizard.go` | `minectl wizard` — interactive TUI wizard for server creation |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START golden-samples -->
+## Golden Samples (follow these patterns)
+| For | Reference | Key patterns |
+|-----|-----------|--------------|
+| Standard CRUD command | `create.go` | `RunE` + `RunFunc` wrapper, flag setup, provisioner factory |
+| Root + global flags | `minectl.go` | `PersistentPreRunE` for logging/UI setup, `PersistentPostRunE` for version check |
+| Interactive command | `wizard.go` | Uses `internal/ui/form.go` for TUI prompts |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup & environment
+- **CLI framework:** Cobra (`github.com/spf13/cobra`)
+- **Build output:** `bin/minectl` (linux), `bin/minectl-darwin`, `bin/minectl.exe` (windows)
+- Version injected via ldflags: `main.version`, `main.commit`, `main.date`
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Build & tests
+- Build: `go build .` or `make build` (cross-platform)
+- Run: `go run .`
+- Test: `go test -v ./...` (tests are in `internal/`, not here)
+- Lint: `golangci-lint run --timeout 10m -E goimports --fix`
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code style & conventions
+- Use Cobra `RunE` (not `Run`) for commands that can fail
+- Wrap `RunE` with `RunFunc()` from `minectl.go` for consistent error handling + exit codes
+- Common flag sets: `--filename` (manifest), `--id` (server ID), `--ssh-key` (private key path)
+- `createUpdatePluginProvisioner()` is the shared factory for commands needing a provisioner
+- Register new commands in `init()` inside `minectl.go`
+- Provide `--help` text for all commands and flags
+- Exit codes: 0 = success, 1 = error (via `os.Exit` in `RunFunc`)
+- Errors: displayed via `minectlUI.ErrorMsg()` (stderr in headless, TUI in interactive)
+- `--headless` flag: enables structured logging, disables TUI rendering
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- Cloud credentials come from environment variables only — never from flags or config files
+- Never log or display cloud tokens
+- Validate manifest paths before reading
+- SSH key paths: validate existence, do not log contents
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] `--help` text is clear and accurate for new/modified commands
+- [ ] New command registered in `minectl.go:init()`
+- [ ] Uses `RunFunc` wrapper for error handling
+- [ ] Flags have meaningful defaults and descriptions
+- [ ] Works in both interactive and `--headless` mode
+- [ ] Errors go through `minectlUI.ErrorMsg()`
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> See **Golden Samples** section above for files that demonstrate correct patterns.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Cobra docs: see `github.com/spf13/cobra` README
+- Check existing commands (especially `create.go`) for patterns
+- Root AGENTS.md for project-wide conventions
+<!-- AGENTS-GENERATED:END help -->

--- a/cmd/minectl/CLAUDE.md
+++ b/cmd/minectl/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add root `AGENTS.md` with verified build/test commands, file map, golden samples, module boundaries, and coding heuristics
- Add scoped `cmd/minectl/AGENTS.md` with Cobra CLI conventions, flag patterns, and security rules
- Add `CLAUDE.md` symlinks for cross-agent compatibility
- Add `.claude/` and `.mcp.json` to `.gitignore`

## Test plan
- [x] All commands in AGENTS.md verified against the codebase (`go build`, `go test`, etc.)
- [x] Structure validated with `validate-structure.sh` — all checks pass
- [x] CLAUDE.md symlinks resolve correctly